### PR TITLE
Add to user preferences ability to set default show/hide button state

### DIFF
--- a/ganttzk/src/main/java/org/zkoss/ganttz/FunctionalityExposedForExtensions.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/FunctionalityExposedForExtensions.java
@@ -243,6 +243,8 @@ public class FunctionalityExposedForExtensions<T> implements IContext<T> {
         result.setShowingReportedHours(planner.showReportedHoursRightNow());
         result.setShowingMoneyCostBar(planner.showMoneyCostBarRightNow());
         result.setShowingAdvances(planner.showAdvancesRightNow());
+        result.setShowingLabels(planner.showLabelsRightNow());
+        result.setShowingResources(planner.showResourcesRightNow());
 
         mapper.register(position, result, data);
 

--- a/ganttzk/src/main/java/org/zkoss/ganttz/Planner.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/Planner.java
@@ -156,6 +156,10 @@ public class Planner extends HtmlMacroComponent  {
 
     private boolean shownMoneyCostBarByDefault = false;
 
+    private boolean shownLabelsByDefault = false;
+
+    private boolean shownResourcesByDefault = false;
+
     private FilterAndParentExpandedPredicates predicate;
 
     private boolean visibleChart;
@@ -430,6 +434,27 @@ public class Planner extends HtmlMacroComponent  {
             showMoneyCostBarButton.setVisible(false);
         }
 
+        // view buttons toggle state so set all off prior to toggling
+        if ( configuration.isShowResourcesOn() ) {
+            showAllResources();
+        }
+
+        if ( configuration.isShowAdvancesOn() ) {
+            showAdvances();
+        }
+
+        if ( configuration.isShowReportedHoursOn() ) {
+            showReportedHours();
+        }
+
+        if ( configuration.isShowLabelsOn() ) {
+           showAllLabels();
+        }
+
+        if ( configuration.isShowMoneyCostBarOn() ) {
+            showMoneyCostBar();
+        }
+
         listZoomLevels.setSelectedIndex(getZoomLevel().ordinal());
 
         this.visibleChart = configuration.isExpandPlanningViewCharts();
@@ -656,7 +681,6 @@ public class Planner extends HtmlMacroComponent  {
     public void showReportedHours() {
         Button showReportedHoursButton = (Button) getFellow("showReportedHours");
         if ( disabilityConfiguration.isReportedHoursEnabled() ) {
-
             if ( isShowingReportedHours ) {
                 context.hideReportedHours();
                 diagramGraph.removePostGraphChangeListener(showReportedHoursOnChange);
@@ -694,28 +718,33 @@ public class Planner extends HtmlMacroComponent  {
 
     public void showAllLabels() {
         Button showAllLabelsButton = (Button) getFellow("showAllLabels");
-        if ( isShowingLabels ) {
-            Clients.evalJavaScript("ganttz.TaskList.getInstance().hideAllTaskLabels()");
-            showAllLabelsButton.setSclass("planner-command show-labels");
-        } else {
-            Clients.evalJavaScript("ganttz.TaskList.getInstance().showAllTaskLabels()");
-            showAllLabelsButton.setSclass("planner-command show-labels clicked");
-        }
+        if ( disabilityConfiguration.isLabelsEnabled() ) {
+	        if ( isShowingLabels ) {
+	            Clients.evalJavaScript("ganttz.TaskList.getInstance().hideAllTaskLabels()");
+	            showAllLabelsButton.setSclass("planner-command show-labels");
+	        } else {
+	            Clients.evalJavaScript("ganttz.TaskList.getInstance().showAllTaskLabels()");
+	            showAllLabelsButton.setSclass("planner-command show-labels clicked");
+	        }
 
-        isShowingLabels = !isShowingLabels;
+	        isShowingLabels = !isShowingLabels;
+        }
     }
 
     public void showAllResources() {
         Button showAllLabelsButton = (Button) getFellow("showAllResources");
-        if ( isShowingResources ) {
-            Clients.evalJavaScript("ganttz.TaskList.getInstance().hideResourceTooltips()");
-            showAllLabelsButton.setSclass("planner-command show-resources");
-        } else {
-            Clients.evalJavaScript("ganttz.TaskList.getInstance().showResourceTooltips()");
-            showAllLabelsButton.setSclass("planner-command show-resources clicked");
-        }
+        if ( disabilityConfiguration.isResourcesEnabled() ) {
+	        if ( isShowingResources ) {
+	            Clients.evalJavaScript("ganttz.TaskList.getInstance().hideResourceTooltips()");
+	            showAllLabelsButton.setSclass("planner-command show-resources");
+	        } else {
+	            Clients.evalJavaScript("ganttz.TaskList.getInstance().showResourceTooltips()");
+	            showAllLabelsButton.setSclass("planner-command show-resources clicked");
+	        }
 
-        isShowingResources = !isShowingResources;
+	        isShowingResources = !isShowingResources;
+
+        }
     }
 
     public void print() {
@@ -752,7 +781,6 @@ public class Planner extends HtmlMacroComponent  {
 
     public void setAreShownAdvancesByDefault(boolean shownAdvanceByDefault) {
         this.shownAdvanceByDefault = shownAdvanceByDefault;
-        this.isShowingAdvances = shownAdvanceByDefault;
     }
 
     public void setAreShownReportedHoursByDefault(boolean shownReportedHoursByDefault) {
@@ -777,6 +805,30 @@ public class Planner extends HtmlMacroComponent  {
 
     public boolean showMoneyCostBarRightNow() {
         return areShownMoneyCostBarByDefault() || isShowingMoneyCostBar;
+    }
+
+    public void setAreShownLabelsByDefault(boolean shownLabelsByDefault) {
+        this.shownLabelsByDefault = shownLabelsByDefault;
+    }
+
+    public boolean areShownLabelsByDefault() {
+        return shownLabelsByDefault;
+    }
+
+    public boolean showLabelsRightNow() {
+        return areShownLabelsByDefault() || isShowingLabels;
+    }
+
+    public void setAreShownResourcesByDefault(boolean shownResourcesByDefault) {
+        this.shownResourcesByDefault = shownResourcesByDefault;
+    }
+
+    public boolean areShownResourcesByDefault() {
+        return shownResourcesByDefault;
+    }
+
+    public boolean showResourcesRightNow() {
+        return areShownResourcesByDefault() || isShowingResources;
     }
 
     public void expandAll() {

--- a/ganttzk/src/main/java/org/zkoss/ganttz/adapters/IDisabilityConfiguration.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/adapters/IDisabilityConfiguration.java
@@ -42,6 +42,10 @@ public interface IDisabilityConfiguration {
 
     public boolean isMoneyCostBarEnabled();
 
+    public boolean isLabelsEnabled();
+
+    public boolean isResourcesEnabled();
+
     public boolean isExpandAllEnabled();
 
     public boolean isFlattenTreeEnabled();

--- a/ganttzk/src/main/java/org/zkoss/ganttz/adapters/PlannerConfiguration.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/adapters/PlannerConfiguration.java
@@ -157,6 +157,10 @@ public class PlannerConfiguration<T> implements IDisabilityConfiguration {
 
     private boolean moneyCostBarEnabled = true;
 
+    private boolean labelsEnabled = true;
+
+    private boolean ResourcesEnabled = true;
+
     private boolean expandAllEnabled = true;
 
     private boolean flattenTreeEnabled = true;
@@ -166,6 +170,16 @@ public class PlannerConfiguration<T> implements IDisabilityConfiguration {
     private boolean renamingTasksEnabled = true;
 
     private boolean treeEditable = true;
+
+    private boolean showResourcesOn = false;
+
+    private boolean showAdvancesOn = false;
+
+    private boolean showReportedHoursOn = false;
+
+    private boolean showLabelsOn = false;
+
+    private boolean showMoneyCostBarOn = false;
 
     private IDetailItemModifier firstLevelModifiers = SeveralModifiers.empty();
 
@@ -355,6 +369,24 @@ public class PlannerConfiguration<T> implements IDisabilityConfiguration {
         return moneyCostBarEnabled;
     }
 
+    public void setLabelsEnabled(boolean labelsEnabled) {
+        this.labelsEnabled = labelsEnabled;
+    }
+
+    @Override
+    public boolean isLabelsEnabled() {
+        return labelsEnabled;
+    }
+
+    public void setResourcesEnabled(boolean ResourcesEnabled) {
+        this.ResourcesEnabled = ResourcesEnabled;
+    }
+
+    @Override
+    public boolean isResourcesEnabled() {
+        return ResourcesEnabled;
+    }
+
     public void setExpandAllEnabled(boolean expandAllEnabled) {
         this.expandAllEnabled = expandAllEnabled;
     }
@@ -493,6 +525,46 @@ public class PlannerConfiguration<T> implements IDisabilityConfiguration {
 
     public void setScheduleBackwards(boolean scheduleBackwards) {
         this.scheduleBackwards = scheduleBackwards;
+    }
+
+    public boolean isShowResourcesOn() {
+        return showResourcesOn;
+    }
+
+    public void setShowResourcesOn(boolean showResourcesOn) {
+        this.showResourcesOn = showResourcesOn;
+    }
+
+    public boolean isShowAdvancesOn() {
+        return showAdvancesOn;
+    }
+
+    public void setShowAdvancesOn(boolean showAdvancesOn) {
+        this.showAdvancesOn = showAdvancesOn;
+    }
+
+    public boolean isShowReportedHoursOn() {
+        return showReportedHoursOn;
+    }
+
+    public void setShowReportedHoursOn(boolean showReportedHoursOn) {
+        this.showReportedHoursOn = showReportedHoursOn;
+    }
+
+    public boolean isShowLabelsOn() {
+        return showLabelsOn;
+    }
+
+    public void setShowLabelsOn(boolean showLabelsOn) {
+        this.showLabelsOn = showLabelsOn;
+    }
+
+    public boolean isShowMoneyCostBarOn() {
+        return showMoneyCostBarOn;
+    }
+
+    public void setShowMoneyCostBarOn(boolean showMoneyCostBarOn) {
+        this.showMoneyCostBarOn = showMoneyCostBarOn;
     }
 
 }

--- a/ganttzk/src/main/java/org/zkoss/ganttz/data/Task.java
+++ b/ganttzk/src/main/java/org/zkoss/ganttz/data/Task.java
@@ -73,6 +73,10 @@ public abstract class Task implements ITaskFundamentalProperties {
 
     private PropertyChangeSupport moneyCostBarProperty = new PropertyChangeSupport(this);
 
+    private PropertyChangeSupport labelsProperty = new PropertyChangeSupport(this);
+
+    private PropertyChangeSupport resourcesProperty = new PropertyChangeSupport(this);
+
     private final ITaskFundamentalProperties fundamentalProperties;
 
     private boolean visible = true;
@@ -84,6 +88,10 @@ public abstract class Task implements ITaskFundamentalProperties {
     private boolean showingReportedHours = false;
 
     private boolean showingMoneyCostBar = false;
+
+    private boolean showingLabels = false;
+
+    private boolean showingResources = false;
 
     private ConstraintViolationNotificator<GanttDate> violationNotificator = ConstraintViolationNotificator.create();
 
@@ -229,6 +237,26 @@ public abstract class Task implements ITaskFundamentalProperties {
 
     public boolean isShowingMoneyCostBar() {
         return showingMoneyCostBar;
+    }
+
+    public void setShowingResources(boolean showingResources) {
+        boolean previousValue = this.showingResources;
+        this.showingResources = showingResources;
+        resourcesProperty.firePropertyChange("showingResources", previousValue, this.showingResources);
+    }
+
+    public boolean isShowingResources() {
+        return showingResources;
+    }
+
+    public void setShowingLabels(boolean showingLabels) {
+        boolean previousValue = this.showingLabels;
+        this.showingLabels = showingLabels;
+        labelsProperty.firePropertyChange("showingLabels", previousValue, this.showingLabels);
+    }
+
+    public boolean isShowingLabels() {
+        return showingLabels;
     }
 
     public String getName() {

--- a/libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/users/entities/User.java
@@ -99,6 +99,16 @@ public class User extends BaseEntity implements IHumanIdentifiable{
 
     private Integer resourcesLoadFilterPeriodTo;
 
+    private boolean showResourcesOn = false;
+
+    private boolean showAdvancesOn = false;
+
+    private boolean showReportedHoursOn = false;
+
+    private boolean showLabelsOn = false;
+
+    private boolean showMoneyCostBarOn = false;
+
     /**
      * Necessary for Hibernate. Please, do not call it.
      */
@@ -448,6 +458,46 @@ public class User extends BaseEntity implements IHumanIdentifiable{
 
     public void setResourcesLoadFilterPeriodTo(Integer period) {
         resourcesLoadFilterPeriodTo = period;
+    }
+
+    public boolean isShowResourcesOn() {
+        return showResourcesOn;
+    }
+
+    public void setShowResourcesOn(boolean showResourcesOn) {
+        this.showResourcesOn = showResourcesOn;
+    }
+
+    public boolean isShowAdvancesOn() {
+        return showAdvancesOn;
+    }
+
+    public void setShowAdvancesOn(boolean showAdvancesOn) {
+        this.showAdvancesOn = showAdvancesOn;
+    }
+
+    public boolean isShowReportedHoursOn() {
+        return showReportedHoursOn;
+    }
+
+    public void setShowReportedHoursOn(boolean showReportedHoursOn) {
+        this.showReportedHoursOn = showReportedHoursOn;
+    }
+
+    public boolean isShowLabelsOn() {
+        return showLabelsOn;
+    }
+
+    public void setShowLabelsOn(boolean showLabelsOn) {
+        this.showLabelsOn = showLabelsOn;
+    }
+
+    public boolean isShowMoneyCostBarOn() {
+        return showMoneyCostBarOn;
+    }
+
+    public void setShowMoneyCostBarOn(boolean showMoneyCostBarOn) {
+            this.showMoneyCostBarOn = showMoneyCostBarOn;
     }
 
 }

--- a/libreplan-business/src/main/resources/db.changelog.xml
+++ b/libreplan-business/src/main/resources/db.changelog.xml
@@ -12,4 +12,5 @@
     <include file="db.changelog-1.3.xml"/>
     <include file="db.changelog-1.4.xml"/>
     <include file="db.changelog-1.5.xml"/>
+    <include file="db.changelog-1.6.xml"/>
 </databaseChangeLog>

--- a/libreplan-business/src/main/resources/org/libreplan/business/users/entities/Users.hbm.xml
+++ b/libreplan-business/src/main/resources/org/libreplan/business/users/entities/Users.hbm.xml
@@ -70,6 +70,16 @@
 
         <property name="resourcesLoadFilterPeriodTo" column="resources_load_filter_period_to"/>
 
+        <property name="showResourcesOn" column="show_resources_on"/>
+
+        <property name="showAdvancesOn" column="show_advances_on"/>
+
+        <property name="showReportedHoursOn" column="show_reported_hours_on"/>
+
+        <property name="showLabelsOn" column="show_labels_on"/>
+
+        <property name="showMoneyCostBarOn" column="show_money_cost_bar_on"/>
+
         <many-to-one name="projectsFilterLabel" cascade="none" lazy="false" column="projects_filter_label_id" />
 
         <many-to-one name="resourcesLoadFilterCriterion" cascade="none" lazy="false"

--- a/libreplan-webapp/src/main/java/org/libreplan/web/planner/company/CompanyPlanningModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/planner/company/CompanyPlanningModel.java
@@ -218,6 +218,7 @@ public class CompanyPlanningModel implements ICompanyPlanningModel {
         addAdditionalCommands(additional, configuration);
         addPrintSupport(configuration);
         disableSomeFeatures(configuration);
+        setDefaultButtonState(configuration,user);
 
         planner.setInitialZoomLevel(getZoomLevel(configuration));
 
@@ -246,6 +247,23 @@ public class CompanyPlanningModel implements ICompanyPlanningModel {
             });
         }
     }
+
+    private void setDefaultButtonState(PlannerConfiguration<TaskElement> configuration, User user) {
+
+// set initial button show mode
+    if ( user.isShowAdvancesOn() ) {
+        configuration.setShowAdvancesOn(user.isShowAdvancesOn());
+	}
+
+    if ( user.isShowReportedHoursOn() ) {
+        configuration.setShowReportedHoursOn(user.isShowReportedHoursOn());
+    }
+
+    if ( user.isShowLabelsOn() ) {
+        configuration.setShowLabelsOn(user.isShowLabelsOn());
+    }
+
+}
 
     private ZoomLevel getZoomLevel(PlannerConfiguration<TaskElement> configuration) {
         ZoomLevel sessionZoom = FilterUtils.readZoomLevelCompanyView();

--- a/libreplan-webapp/src/main/java/org/libreplan/web/planner/order/OrderPlanningModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/planner/order/OrderPlanningModel.java
@@ -354,6 +354,8 @@ public class OrderPlanningModel implements IOrderPlanningModel {
         chartComponent.setHeight("200px");
         appendTabs(chartComponent);
 
+        setDefaultButtonState(configuration,user);
+
         configuration.setChartComponent(chartComponent);
         configureModifiers(planningState.getOrder(), configuration);
         long setConfigurationTime = System.currentTimeMillis();
@@ -393,6 +395,36 @@ public class OrderPlanningModel implements IOrderPlanningModel {
         planner.addGraphChangeListenersFromConfiguration(configuration);
         long overallProgressContentTime = System.currentTimeMillis();
         PROFILING_LOG.debug("overallProgressContent took: " + (System.currentTimeMillis() - overallProgressContentTime));
+    }
+
+    private void setDefaultButtonState(PlannerConfiguration<TaskElement> configuration, User user) {
+
+        // set initial button show mode
+        if ( !planner.areShownAdvancesByDefault() && user.isShowAdvancesOn() ) {
+            configuration.setShowAdvancesOn(user.isShowAdvancesOn());
+            planner.setAreShownAdvancesByDefault(user.isShowAdvancesOn());
+        }
+
+        if ( !planner.areShownReportedHoursByDefault() && user.isShowReportedHoursOn() ) {
+            configuration.setShowReportedHoursOn(user.isShowReportedHoursOn());
+            planner.setAreShownReportedHoursByDefault(user.isShowReportedHoursOn());
+        }
+
+        if ( !planner.areShownMoneyCostBarByDefault() && user.isShowMoneyCostBarOn() ) {
+            configuration.setShowMoneyCostBarOn(user.isShowMoneyCostBarOn());
+            planner.setAreShownMoneyCostBarByDefault(user.isShowMoneyCostBarOn());
+        }
+
+        if ( !planner.areShownLabelsByDefault() && user.isShowLabelsOn() ) {
+            configuration.setShowLabelsOn(user.isShowLabelsOn());
+            planner.setAreShownLabelsByDefault(user.isShowLabelsOn());
+        }
+
+        if ( !planner.areShownResourcesByDefault() && user.isShowResourcesOn() ) {
+            configuration.setShowResourcesOn(user.isShowResourcesOn());
+            planner.setAreShownResourcesByDefault(user.isShowResourcesOn());
+        }
+
     }
 
     private ZoomLevel getZoomLevel(PlannerConfiguration<TaskElement> configuration, Order order) {

--- a/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/ISettingsModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/ISettingsModel.java
@@ -101,4 +101,23 @@ public interface ISettingsModel {
 
     void setResourcesLoadFilterCriterion(Criterion criterion);
 
+    boolean isShowResourcesOn();
+
+    void setShowResourcesOn(boolean showResourcesOn);
+
+    boolean isShowAdvancesOn();
+
+    void setShowAdvancesOn(boolean showAdvancesOn);
+
+    boolean isShowReportedHoursOn();
+
+    void setShowReportedHoursOn(boolean showReportedHoursOn);
+
+    boolean isShowLabelsOn();
+
+    void setShowLabelsOn(boolean showLabelsOn);
+
+    boolean isShowMoneyCostBarOn();
+
+    void setShowMoneyCostBarOn(boolean showMoneyCostBarOn);
 }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/SettingsController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/SettingsController.java
@@ -314,4 +314,43 @@ public class SettingsController extends GenericForwardComposer {
         settingsModel.setResourcesLoadFilterCriterion(criterion);
     }
 
+    public boolean isShowResourcesOn() {
+        return settingsModel.isShowResourcesOn();
+    }
+
+    public void setShowResourcesOn(boolean showResourcesOn) {
+        settingsModel.setShowResourcesOn(showResourcesOn);
+    }
+
+    public boolean isShowAdvancesOn() {
+        return settingsModel.isShowAdvancesOn();
+    }
+
+    public void setShowAdvancesOn(boolean showAdvancesOn) {
+        settingsModel.setShowAdvancesOn(showAdvancesOn);
+    }
+
+    public boolean isShowReportedHoursOn() {
+        return settingsModel.isShowReportedHoursOn();
+    }
+
+    public void setShowReportedHoursOn(boolean showReportedHoursOn) {
+        settingsModel.setShowReportedHoursOn(showReportedHoursOn);
+    }
+
+    public boolean isShowLabelsOn() {
+        return settingsModel.isShowLabelsOn();
+    }
+
+    public void setShowLabelsOn(boolean showLabelsOn) {
+        settingsModel.setShowLabelsOn(showLabelsOn);
+    }
+
+    public boolean isShowMoneyCostBarOn() {
+        return settingsModel.isShowMoneyCostBarOn();
+    }
+
+    public void setShowMoneyCostBarOn(boolean showMoneyCostBarOn) {
+        settingsModel.setShowMoneyCostBarOn(showMoneyCostBarOn);
+    }
 }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/SettingsModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/users/settings/SettingsModel.java
@@ -311,4 +311,53 @@ public class SettingsModel implements ISettingsModel {
         user.setResourcesLoadFilterCriterion(criterion);
     }
 
+    @Override
+    public boolean isShowResourcesOn() {
+        return user.isShowResourcesOn();
+    }
+
+    @Override
+    public void setShowResourcesOn(boolean showResourcesOn) {
+        user.setShowResourcesOn(showResourcesOn);
+    }
+
+    @Override
+    public boolean isShowAdvancesOn() {
+        return user.isShowAdvancesOn();
+    }
+
+    @Override
+    public void setShowAdvancesOn(boolean showAdvancesOn) {
+        user.setShowAdvancesOn(showAdvancesOn);
+    }
+
+    @Override
+    public boolean isShowReportedHoursOn() {
+        return user.isShowReportedHoursOn();
+    }
+
+    @Override
+    public void setShowReportedHoursOn(boolean showReportedHoursOn) {
+        user.setShowReportedHoursOn(showReportedHoursOn);
+    }
+
+    @Override
+    public boolean isShowLabelsOn() {
+        return user.isShowLabelsOn();
+    }
+
+    @Override
+    public void setShowLabelsOn(boolean showLabelsOn) {
+        user.setShowLabelsOn(showLabelsOn);
+    }
+
+    @Override
+    public boolean isShowMoneyCostBarOn() {
+        return user.isShowMoneyCostBarOn();
+    }
+
+    @Override
+    public void setShowMoneyCostBarOn(boolean showMoneyCostBarOn) {
+            user.setShowMoneyCostBarOn(showMoneyCostBarOn);
+    }
 }

--- a/libreplan-webapp/src/main/webapp/WEB-INF/zk.xml
+++ b/libreplan-webapp/src/main/webapp/WEB-INF/zk.xml
@@ -1,9 +1,5 @@
 <zk>
-    <log>
-        <log-base/>
-    </log>
-
-    <desktop-config>
+        <desktop-config>
         <!--
         Seconds it takes between requests for a desktop to be invalidated.
         A timer is introduced to avoid invalidation of pages still open.

--- a/libreplan-webapp/src/main/webapp/myaccount/settings.zul
+++ b/libreplan-webapp/src/main/webapp/myaccount/settings.zul
@@ -122,6 +122,35 @@
                                     </grid>
                                 </row>
                                 <row>
+                                    <label value="${i18n:_('Planning view modes on')}" />
+                                    <grid>
+                                        <columns>
+                                            <column />
+                                            <column />
+                                            <column />
+                                        </columns>
+                                        <rows>
+                                            <row>
+                                                <checkbox id="showResourcesOn"
+                                                          label="${i18n:_('Show resources')}"
+                                                          checked="@{settingsController.showResourcesOn}"/>
+                                                <checkbox id="showAdvancesOn"
+                                                          label="${i18n:_('Show progress')}"
+                                                          checked="@{settingsController.showAdvancesOn}"/>
+                                                <checkbox id="showReportedHoursOn"
+                                                          label="${i18n:_('Show reported hours')}"
+                                                          checked="@{settingsController.showReportedHoursOn}"/>
+                                                <checkbox id="showLabelsOn"
+                                                          label="${i18n:_('Show labels')}"
+                                                          checked="@{settingsController.showLabelsOn}"/>
+                                                <checkbox id="showMoneyCostBarOn"
+                                                          label="${i18n:_('Show money cost bar')}"
+                                                          checked="@{settingsController.showMoneyCostBarOn}"/>
+                                            </row>
+                                        </rows>
+                                    </grid>
+                                </row>
+                                <row>
                                     <label value="${i18n:_('Projects view filtering')}" />
                                     <hbox>
                                         <label value="${i18n:_('Label filter')}" />


### PR DESCRIPTION
Added additional user preferences settings to allow setting the default state of the planning view show buttons (resources, progress, reported hours, labels, and money cost bar)