### PR TITLE
Remove notifications from queue when associated project or task deleted

### DIFF
--- a/libreplan-business/src/main/java/org/libreplan/business/email/daos/EmailNotificationDAO.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/email/daos/EmailNotificationDAO.java
@@ -23,8 +23,12 @@ import org.hibernate.criterion.Restrictions;
 import org.libreplan.business.common.daos.GenericDAOHibernate;
 import org.libreplan.business.email.entities.EmailNotification;
 import org.libreplan.business.email.entities.EmailTemplateEnum;
+import org.libreplan.business.orders.entities.Order;
+import org.libreplan.business.planner.entities.TaskElement;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
+//import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -47,6 +51,22 @@ public class EmailNotificationDAO
         return getSession()
                 .createCriteria(EmailNotification.class)
                 .add(Restrictions.eq("type", enumeration))
+                .list();
+    }
+
+    @Override
+    public List<EmailNotification> getAllByProject(TaskElement taskElement) {
+       return getSession()
+               .createCriteria(EmailNotification.class)
+               .add(Restrictions.eq("project", taskElement))
+               .list();
+    }
+
+    @Override
+    public List<EmailNotification> getAllByTask(TaskElement taskElement) {
+        return getSession()
+                .createCriteria(EmailNotification.class)
+                .add(Restrictions.eq("task", taskElement))
                 .list();
     }
 
@@ -87,6 +107,28 @@ public class EmailNotificationDAO
                 .createCriteria(EmailNotification.class)
                 .add(Restrictions.eq("id", notification.getId()))
                 .uniqueResult() == null;
+    }
+
+    @Override
+    public boolean deleteByProject(TaskElement taskElement) {
+        List<EmailNotification> notifications = getAllByProject(taskElement);
+
+        for (Object item : notifications){
+            getSession().delete(item);
+        }
+
+        return getAllByProject(taskElement).isEmpty();
+    }
+
+    @Override
+    public boolean deleteByTask(TaskElement taskElement) {
+        List<EmailNotification> notifications = getAllByTask(taskElement);
+
+        for (Object item : notifications){
+            getSession().delete(item);
+        }
+
+        return getAllByTask(taskElement).isEmpty();
     }
 
 }

--- a/libreplan-business/src/main/java/org/libreplan/business/email/daos/IEmailNotificationDAO.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/email/daos/IEmailNotificationDAO.java
@@ -22,6 +22,8 @@ package org.libreplan.business.email.daos;
 import org.libreplan.business.common.daos.IGenericDAO;
 import org.libreplan.business.email.entities.EmailNotification;
 import org.libreplan.business.email.entities.EmailTemplateEnum;
+import org.libreplan.business.orders.entities.Order;
+import org.libreplan.business.planner.entities.TaskElement;
 
 import java.util.List;
 
@@ -36,9 +38,18 @@ public interface IEmailNotificationDAO extends IGenericDAO<EmailNotification, Lo
 
     List<EmailNotification> getAllByType(EmailTemplateEnum enumeration);
 
+    List<EmailNotification> getAllByProject(TaskElement taskElement);
+
+    List<EmailNotification> getAllByTask(TaskElement taskElement);
+
     boolean deleteAll();
 
     boolean deleteAllByType(EmailTemplateEnum enumeration);
 
     boolean deleteById(EmailNotification notification);
+
+    boolean deleteByProject(TaskElement taskElement);
+
+    boolean deleteByTask(TaskElement taskElement);
+
 }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/email/EmailNotificationModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/email/EmailNotificationModel.java
@@ -22,6 +22,7 @@ package org.libreplan.web.email;
 import org.libreplan.business.common.exceptions.ValidationException;
 import org.libreplan.business.email.daos.IEmailNotificationDAO;
 import org.libreplan.business.email.entities.EmailTemplateEnum;
+import org.libreplan.business.orders.entities.Order;
 import org.libreplan.business.email.entities.EmailNotification;
 
 import org.libreplan.business.planner.entities.TaskElement;
@@ -70,6 +71,17 @@ public class EmailNotificationModel implements IEmailNotificationModel {
 
     @Override
     @Transactional
+    public List<EmailNotification> getAllByProject(TaskElement taskElement) {
+        return emailNotificationDAO.getAllByProject(taskElement);
+    }
+    @Override
+    @Transactional
+    public List<EmailNotification> getAllByTask(TaskElement taskElement) {
+        return emailNotificationDAO.getAllByTask(taskElement);
+    }
+
+    @Override
+    @Transactional
     public boolean deleteAll() {
         return emailNotificationDAO.deleteAll();
     }
@@ -83,6 +95,18 @@ public class EmailNotificationModel implements IEmailNotificationModel {
     @Transactional
     public boolean deleteById(EmailNotification notification){
         return emailNotificationDAO.deleteById(notification);
+    }
+
+    @Override
+    @Transactional
+    public boolean deleteByProject(TaskElement taskElement) {
+        return emailNotificationDAO.deleteByProject(taskElement);
+    }
+
+    @Override
+    @Transactional
+    public boolean deleteByTask(TaskElement taskElement) {
+        return emailNotificationDAO.deleteByTask(taskElement);
     }
 
     @Override
@@ -110,11 +134,12 @@ public class EmailNotificationModel implements IEmailNotificationModel {
         this.emailNotification.setProject(project);
     }
 
-
+    @Override
     public EmailNotification getEmailNotification() {
         return emailNotification;
     }
 
+    @Override
     public void setNewObject(){
         this.emailNotification = new EmailNotification();
     }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/email/IEmailNotificationModel.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/email/IEmailNotificationModel.java
@@ -21,6 +21,7 @@ package org.libreplan.web.email;
 
 import org.libreplan.business.common.exceptions.ValidationException;
 import org.libreplan.business.email.entities.EmailTemplateEnum;
+import org.libreplan.business.orders.entities.Order;
 import org.libreplan.business.email.entities.EmailNotification;
 import org.libreplan.business.planner.entities.TaskElement;
 import org.libreplan.business.resources.entities.Resource;
@@ -41,11 +42,19 @@ public interface IEmailNotificationModel {
 
     List<EmailNotification> getAllByType(EmailTemplateEnum enumeration);
 
+    List<EmailNotification> getAllByProject(TaskElement taskElement);
+
+    List<EmailNotification> getAllByTask(TaskElement taskElement);
+
     boolean deleteAll();
 
     boolean deleteAllByType(EmailTemplateEnum enumeration);
 
     boolean deleteById(EmailNotification notification);
+
+    boolean deleteByProject(TaskElement taskElement);
+
+    boolean deleteByTask(TaskElement taskElement);
 
     void setType(EmailTemplateEnum type);
 
@@ -60,4 +69,5 @@ public interface IEmailNotificationModel {
     EmailNotification getEmailNotification();
 
     void setNewObject();
+
 }

--- a/libreplan-webapp/src/test/java/org/libreplan/web/test/ws/email/EmailTest.java
+++ b/libreplan-webapp/src/test/java/org/libreplan/web/test/ws/email/EmailTest.java
@@ -2,7 +2,9 @@ package org.libreplan.web.test.ws.email;
 
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
 import org.libreplan.business.common.Registry;
@@ -165,6 +167,20 @@ public class EmailTest {
         emailNotificationDAO.deleteAll();
 
         assertTrue(EmailConnectionValidator.exceptionType instanceof MessagingException);
+    }
+
+    @Test
+    @Transactional
+    public void testDDeleteEmailNotification() {
+        EmailTemplate emailTemplate = createEmailTemplate();
+        emailTemplateDAO.save(emailTemplate);
+
+        EmailNotification emailNotification = createEmailNotification();
+        emailNotificationDAO.save(emailNotification);
+
+        emailTemplateDAO.delete(emailTemplate);
+        boolean result = emailNotificationDAO.deleteByProject(emailNotification.getProject());
+        assertTrue(result);
     }
 
     private EmailTemplate createEmailTemplate() {


### PR DESCRIPTION
Prevents a HibernateObjectRetrievalFailureException from being thrown when a scheduled email notification
job attempts to send a notification associated to a project or task that was deleted prior to
the scheduled job running.

Fixes #4