### PR TITLE
Fix lazyinitialization listing a users profiles roles

### DIFF
--- a/libreplan-business/src/main/resources/org/libreplan/business/users/entities/Users.hbm.xml
+++ b/libreplan-business/src/main/resources/org/libreplan/business/users/entities/Users.hbm.xml
@@ -53,7 +53,7 @@
         </set>
 
         <!-- Index created in a database-object section -->
-        <set name="profiles" table="user_profiles">
+        <set name="profiles" table="user_profiles" lazy="false">
             <key column="user_id"/>
             <many-to-many column="profile_id" class="org.libreplan.business.users.entities.Profile"/>
         </set>


### PR DESCRIPTION
Add a lazy=false to User hibernate config as workaround.

Fixes #13