### PR TITLE
Restrict email notifications to leaf node tasks

### DIFF
--- a/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldFinish.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldFinish.java
@@ -122,7 +122,7 @@ public class SendEmailOnTaskShouldFinish implements IEmailNotificationJob {
         for (TaskElement item : tasks) {
             DateTime endDate = new DateTime(item.getEndDate());
 
-            if ( dateTimeComparator.compare(currentDate, endDate) == 0 ) {
+            if ( dateTimeComparator.compare(currentDate, endDate) == 0 && item.isLeaf() ) {
                 // Get all resources for current task and send them email notification
                 sendEmailNotificationAboutTaskShouldFinish(item);
             }

--- a/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldStart.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldStart.java
@@ -124,7 +124,7 @@ public class SendEmailOnTaskShouldStart implements IEmailNotificationJob {
         for (TaskElement item : tasks) {
             DateTime startDate = new DateTime(item.getStartDate());
 
-            if ( dateTimeComparator.compare(currentDate, startDate) == 0) {
+            if ( dateTimeComparator.compare(currentDate, startDate) == 0 && item.isLeaf() ) {
                 // Get all resources for current task and send them email notification
                 sendEmailNotificationAboutTaskShouldStart(item);
             }


### PR DESCRIPTION
Email notifications for tasks to start or finish should only be sent to individual tasks not
to task groups.

Fixes #20