### PR TITLE
Use top level project task for grouped sub tasks

### DIFF
--- a/libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskElement.java
+++ b/libreplan-business/src/main/java/org/libreplan/business/planner/entities/TaskElement.java
@@ -243,7 +243,8 @@ public abstract class TaskElement extends BaseEntity {
     }
 
     public String getProjectCode() {
-        return getOrderElement().getOrder().getCode();
+        //then get the top level project code
+        return getTopMost().getOrderElement().getOrder().getCode();
     }
 
     public void setName(String name) {

--- a/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnMilestoneReached.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnMilestoneReached.java
@@ -113,8 +113,8 @@ public class SendEmailOnMilestoneReached implements IEmailNotificationJob {
 
     private void sendEmailNotificationToManager(TaskElement item) {
         String responsible = "";
-        if ( item.getParent().getOrderElement().getOrder().getResponsible() != null ) {
-            responsible = item.getParent().getOrderElement().getOrder().getResponsible();
+        if ( item.getTopMost().getOrderElement().getOrder().getResponsible() != null ) {
+            responsible = item.getTopMost().getOrderElement().getOrder().getResponsible();
         }
 
         User user = null;
@@ -130,7 +130,7 @@ public class SendEmailOnMilestoneReached implements IEmailNotificationJob {
 	            emailNotificationModel.setUpdated(new Date());
 	            emailNotificationModel.setResource(user.getWorker());
 	            emailNotificationModel.setTask(item);
-	            emailNotificationModel.setProject(item.getParent());
+	            emailNotificationModel.setProject(item.getTopMost());
 	            emailNotificationModel.confirmSave();
 	        }
 	    } catch (InstanceNotFoundException e) {

--- a/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldFinish.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldFinish.java
@@ -145,7 +145,7 @@ public class SendEmailOnTaskShouldFinish implements IEmailNotificationJob {
                 emailNotificationModel.setUpdated(new Date());
                 emailNotificationModel.setResource(resourceItem);
                 emailNotificationModel.setTask(item);
-                emailNotificationModel.setProject(item.getParent());
+                emailNotificationModel.setProject(item.getTopMost());
                 emailNotificationModel.confirmSave();
             }
         }

--- a/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldStart.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/importers/notifications/realization/SendEmailOnTaskShouldStart.java
@@ -147,7 +147,7 @@ public class SendEmailOnTaskShouldStart implements IEmailNotificationJob {
                 emailNotificationModel.setUpdated(new Date());
                 emailNotificationModel.setResource(resourceItem);
                 emailNotificationModel.setTask(item);
-                emailNotificationModel.setProject(item.getParent());
+                emailNotificationModel.setProject(item.getTopMost());
                 emailNotificationModel.confirmSave();
             }
         }

--- a/libreplan-webapp/src/main/java/org/libreplan/web/planner/taskedition/TaskPropertiesController.java
+++ b/libreplan-webapp/src/main/java/org/libreplan/web/planner/taskedition/TaskPropertiesController.java
@@ -800,7 +800,7 @@ public class TaskPropertiesController extends GenericForwardComposer<Component> 
 
             emailNotificationModel.setTask(currentTaskElement.getTaskSource().getTask());
 
-            emailNotificationModel.setProject(currentTaskElement.getParent().getTaskSource().getTask());
+            emailNotificationModel.setProject(currentTaskElement.getTopMost().getTaskSource().getTask());
 
             emailNotificationModel.confirmSave();
         } catch (DataIntegrityViolationException e) {


### PR DESCRIPTION
Instead of using the group task as the project task need to pull the top level parent.
A grouped task will have as parent the group not the project.

Fixes #21